### PR TITLE
Make collapse mode the default for case cards

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -47,11 +47,11 @@ function createCaseCard(caseResult) {
         ? `Error ${caseResult.status}`
         : escapeHtml(extractStatusSummary(caseResult.data))}
     </span>
-    <button class="toggle-btn" aria-label="Toggle details">&#x25BC;</button>
+    <button class="toggle-btn" aria-label="Toggle details">&#x25B6;</button>
   `;
 
   const body = document.createElement('div');
-  body.className = 'case-body';
+  body.className = 'case-body collapsed';
 
   if (caseResult.error) {
     body.innerHTML = `


### PR DESCRIPTION
## Summary
- Case cards now start collapsed by default instead of expanded, showing just the header (receipt number + status badge)
- Users can click individual headers or use "Expand All" to see full details

Closes #1

## Test plan
- [x] Open the extension popup with loaded cases and verify all cards are collapsed by default
- [x] Click a card header to expand it and verify the toggle arrow updates
- [x] Use "Expand All" / "Collapse All" buttons to verify bulk controls still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)