### PR TITLE
Add Jest test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .claude/
+node_modules/
+coverage/

--- a/background.js
+++ b/background.js
@@ -92,3 +92,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 });
+
+if (typeof module !== 'undefined') {
+  module.exports = { fetchCaseData, fetchAllCases };
+}

--- a/content.js
+++ b/content.js
@@ -59,7 +59,12 @@ const observer = new MutationObserver(() => {
   }
 });
 
-observer.observe(document.body, { childList: true, subtree: true });
+// Initialize only in browser extension context (not in tests)
+if (typeof module === 'undefined') {
+  observer.observe(document.body, { childList: true, subtree: true });
+  main();
+}
 
-// Also run immediately in case content is already loaded
-main();
+if (typeof module !== 'undefined') {
+  module.exports = { extractReceiptNumbers, waitForContent, RECEIPT_REGEX };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "uscis-api-extension",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest",
+    "test:coverage": "jest --coverage"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jest-environment-jsdom": "^29.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "setupFiles": ["./tests/setup.js"],
+    "testMatch": ["**/tests/**/*.test.js"]
+  }
+}

--- a/popup.js
+++ b/popup.js
@@ -226,3 +226,16 @@ function showEmptyState() {
   document.getElementById('empty-state').classList.remove('hidden');
   document.getElementById('status').textContent = 'No cases loaded';
 }
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    extractStatusSummary,
+    escapeHtml,
+    renderJsonTree,
+    createCaseCard,
+    renderCases,
+    toggleAll,
+    updateTimestamp,
+    showEmptyState,
+  };
+}

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,0 +1,230 @@
+const { fetchCaseData, fetchAllCases } = require('../background');
+
+const API_BASE = 'https://my.uscis.gov/account/case-service/api/cases/';
+
+beforeEach(() => {
+  fetch.mockClear();
+});
+
+describe('fetchCaseData', () => {
+  test('returns data on a successful 200 response', async () => {
+    const mockData = { caseStatus: 'Case Was Approved', receiptNumber: 'IOE1234567890' };
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockData,
+    });
+
+    const result = await fetchCaseData('IOE1234567890');
+
+    expect(result).toEqual({
+      receiptNumber: 'IOE1234567890',
+      error: false,
+      status: 200,
+      data: mockData,
+    });
+  });
+
+  test('calls the correct API endpoint', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    await fetchCaseData('EAC9876543210');
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${API_BASE}EAC9876543210`,
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'include',
+        headers: expect.objectContaining({ Accept: 'application/json' }),
+      })
+    );
+  });
+
+  test('returns error result on a non-ok HTTP response', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    const result = await fetchCaseData('IOE1234567890');
+
+    expect(result).toEqual({
+      receiptNumber: 'IOE1234567890',
+      error: true,
+      status: 404,
+      statusText: 'Not Found',
+      data: null,
+    });
+  });
+
+  test('returns error result on a 401 Unauthorized response', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    const result = await fetchCaseData('IOE1234567890');
+
+    expect(result.error).toBe(true);
+    expect(result.status).toBe(401);
+    expect(result.data).toBeNull();
+  });
+
+  test('returns error result when fetch throws a network error', async () => {
+    fetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await fetchCaseData('IOE1234567890');
+
+    expect(result).toEqual({
+      receiptNumber: 'IOE1234567890',
+      error: true,
+      status: 0,
+      statusText: 'Network error',
+      data: null,
+    });
+  });
+
+  test('includes the receipt number in all result shapes', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+    const successResult = await fetchCaseData('WAC1111111111');
+    expect(successResult.receiptNumber).toBe('WAC1111111111');
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Server Error' });
+    const errorResult = await fetchCaseData('LIN2222222222');
+    expect(errorResult.receiptNumber).toBe('LIN2222222222');
+  });
+
+  test('handles a 500 server error', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    const result = await fetchCaseData('IOE1234567890');
+
+    expect(result.error).toBe(true);
+    expect(result.status).toBe(500);
+    expect(result.statusText).toBe('Internal Server Error');
+  });
+});
+
+describe('fetchAllCases', () => {
+  test('returns an empty array for an empty input', async () => {
+    const results = await fetchAllCases([]);
+    expect(results).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('fetches a single receipt number', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ caseStatus: 'Approved' }),
+    });
+
+    const results = await fetchAllCases(['IOE1234567890']);
+    expect(results).toHaveLength(1);
+    expect(results[0].receiptNumber).toBe('IOE1234567890');
+    expect(results[0].error).toBe(false);
+  });
+
+  test('fetches all receipt numbers when count <= concurrency limit', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    const receiptNumbers = ['IOE1111111111', 'EAC2222222222', 'WAC3333333333'];
+    const results = await fetchAllCases(receiptNumbers);
+
+    expect(results).toHaveLength(3);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('fetches all receipt numbers when count exceeds concurrency limit', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    const receiptNumbers = [
+      'IOE1111111111',
+      'EAC2222222222',
+      'WAC3333333333',
+      'LIN4444444444',
+      'SRC5555555555',
+    ];
+    const results = await fetchAllCases(receiptNumbers);
+
+    expect(results).toHaveLength(5);
+    expect(fetch).toHaveBeenCalledTimes(5);
+  });
+
+  test('preserves the order of results matching the input order', async () => {
+    fetch.mockImplementation((url) => {
+      const rn = url.split('/').pop();
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: rn }),
+      });
+    });
+
+    const receiptNumbers = ['IOE1111111111', 'EAC2222222222', 'WAC3333333333'];
+    const results = await fetchAllCases(receiptNumbers);
+
+    expect(results[0].receiptNumber).toBe('IOE1111111111');
+    expect(results[1].receiptNumber).toBe('EAC2222222222');
+    expect(results[2].receiptNumber).toBe('WAC3333333333');
+  });
+
+  test('handles mixed success and error responses', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: false, status: 401, statusText: 'Unauthorized' })
+      .mockRejectedValueOnce(new Error('Timeout'));
+
+    const results = await fetchAllCases([
+      'IOE1111111111',
+      'EAC2222222222',
+      'WAC3333333333',
+    ]);
+
+    expect(results[0].error).toBe(false);
+    expect(results[1].error).toBe(true);
+    expect(results[1].status).toBe(401);
+    expect(results[2].error).toBe(true);
+    expect(results[2].status).toBe(0);
+    expect(results[2].statusText).toBe('Timeout');
+  });
+
+  test('processes exactly CONCURRENCY=3 items per batch', async () => {
+    const callOrder = [];
+    fetch.mockImplementation((url) => {
+      callOrder.push(url.split('/').pop());
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({}) });
+    });
+
+    // 4 items: first batch of 3, second batch of 1
+    const receiptNumbers = [
+      'IOE0000000001',
+      'IOE0000000002',
+      'IOE0000000003',
+      'IOE0000000004',
+    ];
+    await fetchAllCases(receiptNumbers);
+
+    expect(fetch).toHaveBeenCalledTimes(4);
+    // All receipt numbers must appear in the call order
+    receiptNumbers.forEach((rn) => expect(callOrder).toContain(rn));
+  });
+});

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,0 +1,144 @@
+// Must be called before requiring content.js so that the module-level main()
+// call does not spin up real timers.
+jest.useFakeTimers();
+
+const { extractReceiptNumbers, waitForContent, RECEIPT_REGEX } = require('../content');
+
+describe('RECEIPT_REGEX', () => {
+  test('matches all valid prefixes', () => {
+    const prefixes = ['IOE', 'EAC', 'WAC', 'LIN', 'SRC', 'NBC', 'MSC', 'YSC', 'MCT'];
+    prefixes.forEach((prefix) => {
+      const num = `${prefix}1234567890`;
+      expect(num.match(RECEIPT_REGEX)).not.toBeNull();
+    });
+  });
+
+  test('does not match unknown prefix', () => {
+    expect('ABC1234567890'.match(RECEIPT_REGEX)).toBeNull();
+  });
+
+  test('requires exactly 10 digits', () => {
+    expect('IOE123456789'.match(RECEIPT_REGEX)).toBeNull();   // 9 digits
+    expect('IOE1234567890'.match(RECEIPT_REGEX)).not.toBeNull(); // 10 digits
+    // 11-digit string: word boundary prevents a match of IOE + first 10 chars
+    expect('IOE12345678901'.match(RECEIPT_REGEX)).toBeNull();
+  });
+});
+
+describe('extractReceiptNumbers', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('returns empty array when no receipt numbers are present', () => {
+    document.body.innerHTML = '<p>No receipt numbers here</p>';
+    expect(extractReceiptNumbers()).toEqual([]);
+  });
+
+  test.each([
+    ['IOE', 'IOE1234567890'],
+    ['EAC', 'EAC1234567890'],
+    ['WAC', 'WAC1234567890'],
+    ['LIN', 'LIN1234567890'],
+    ['SRC', 'SRC1234567890'],
+    ['NBC', 'NBC1234567890'],
+    ['MSC', 'MSC1234567890'],
+    ['YSC', 'YSC1234567890'],
+    ['MCT', 'MCT1234567890'],
+  ])('recognises %s prefix', (_prefix, receiptNumber) => {
+    document.body.innerHTML = `<p>${receiptNumber}</p>`;
+    expect(extractReceiptNumbers()).toContain(receiptNumber);
+  });
+
+  test('extracts multiple different receipt numbers', () => {
+    document.body.innerHTML = '<p>IOE1234567890 and EAC9876543210</p>';
+    const result = extractReceiptNumbers();
+    expect(result).toHaveLength(2);
+    expect(result).toContain('IOE1234567890');
+    expect(result).toContain('EAC9876543210');
+  });
+
+  test('deduplicates repeated receipt numbers', () => {
+    document.body.innerHTML = '<p>IOE1234567890 and IOE1234567890 again</p>';
+    const result = extractReceiptNumbers();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe('IOE1234567890');
+  });
+
+  test('returns results in sorted (ascending) order', () => {
+    document.body.innerHTML = '<p>WAC1234567890 IOE1234567890 EAC1234567890</p>';
+    expect(extractReceiptNumbers()).toEqual([
+      'EAC1234567890',
+      'IOE1234567890',
+      'WAC1234567890',
+    ]);
+  });
+
+  test('does not match unknown prefixes', () => {
+    document.body.innerHTML = '<p>ABC1234567890 XYZ9876543210</p>';
+    expect(extractReceiptNumbers()).toEqual([]);
+  });
+
+  test('does not match fewer than 10 digits', () => {
+    document.body.innerHTML = '<p>IOE123456789</p>';
+    expect(extractReceiptNumbers()).toEqual([]);
+  });
+
+  test('does not match more than 10 digits (word boundary)', () => {
+    document.body.innerHTML = '<p>IOE12345678901</p>';
+    expect(extractReceiptNumbers()).toEqual([]);
+  });
+
+  test('extracts receipt numbers from nested HTML elements', () => {
+    document.body.innerHTML =
+      '<div><p>Case: <strong>IOE1234567890</strong></p></div>';
+    expect(extractReceiptNumbers()).toContain('IOE1234567890');
+  });
+
+  test('handles empty page body', () => {
+    document.body.innerHTML = '';
+    expect(extractReceiptNumbers()).toEqual([]);
+  });
+});
+
+describe('waitForContent', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+    document.body.innerHTML = '';
+  });
+
+  test('resolves immediately when receipt numbers are already present', async () => {
+    document.body.innerHTML = '<p>IOE1234567890</p>';
+    const result = await waitForContent(5, 100);
+    expect(result).toContain('IOE1234567890');
+  });
+
+  test('resolves with empty array after exhausting maxAttempts', async () => {
+    document.body.innerHTML = '<p>No receipt numbers</p>';
+    const promise = waitForContent(3, 100);
+    // Drain all pending timers from this call (3 intervals max)
+    jest.runAllTimers();
+    const result = await promise;
+    expect(result).toEqual([]);
+  });
+
+  test('resolves when receipt numbers appear between polling intervals', async () => {
+    document.body.innerHTML = '<p>No receipt numbers yet</p>';
+    const promise = waitForContent(5, 100);
+
+    // First synchronous check found nothing; advance one interval
+    jest.advanceTimersByTime(100);
+    // Now add a receipt number before the next check fires
+    document.body.innerHTML = '<p>IOE1234567890</p>';
+    jest.advanceTimersByTime(100);
+
+    const result = await promise;
+    expect(result).toContain('IOE1234567890');
+  });
+
+  test('returns multiple receipt numbers found at first check', async () => {
+    document.body.innerHTML = '<p>IOE1234567890 EAC9876543210</p>';
+    const result = await waitForContent(5, 100);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -1,0 +1,451 @@
+const {
+  extractStatusSummary,
+  escapeHtml,
+  renderJsonTree,
+  createCaseCard,
+  renderCases,
+  toggleAll,
+  updateTimestamp,
+  showEmptyState,
+} = require('../popup');
+
+// Minimal popup DOM used by functions that read/write element IDs
+function setupPopupDom() {
+  document.body.innerHTML = `
+    <div id="status"></div>
+    <div id="last-updated"></div>
+    <div id="cases-container" class="hidden"></div>
+    <div id="empty-state" class="hidden"></div>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// extractStatusSummary
+// ---------------------------------------------------------------------------
+describe('extractStatusSummary', () => {
+  test('returns caseStatus when present', () => {
+    expect(extractStatusSummary({ caseStatus: 'Approved' })).toBe('Approved');
+  });
+
+  test('returns currentStatus when caseStatus is absent', () => {
+    expect(extractStatusSummary({ currentStatus: 'Pending' })).toBe('Pending');
+  });
+
+  test('returns status when higher-priority fields are absent', () => {
+    expect(extractStatusSummary({ status: 'Active' })).toBe('Active');
+  });
+
+  test('returns formType as last-resort field', () => {
+    expect(extractStatusSummary({ formType: 'I-485' })).toBe('I-485');
+  });
+
+  test('returns "View Details" when no recognised field is present', () => {
+    expect(extractStatusSummary({})).toBe('View Details');
+  });
+
+  test('returns "View Details" for null', () => {
+    expect(extractStatusSummary(null)).toBe('View Details');
+  });
+
+  test('returns "View Details" for undefined', () => {
+    expect(extractStatusSummary(undefined)).toBe('View Details');
+  });
+
+  test('caseStatus takes priority over all other fields', () => {
+    expect(
+      extractStatusSummary({
+        caseStatus: 'Approved',
+        currentStatus: 'Pending',
+        status: 'Active',
+        formType: 'I-485',
+      })
+    ).toBe('Approved');
+  });
+
+  test('currentStatus takes priority over status and formType', () => {
+    expect(
+      extractStatusSummary({
+        currentStatus: 'Pending',
+        status: 'Active',
+        formType: 'I-485',
+      })
+    ).toBe('Pending');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeHtml
+// ---------------------------------------------------------------------------
+describe('escapeHtml', () => {
+  test('returns plain text unchanged', () => {
+    expect(escapeHtml('Hello World')).toBe('Hello World');
+  });
+
+  test('escapes < and >', () => {
+    const result = escapeHtml('<script>');
+    expect(result).toContain('&lt;');
+    expect(result).toContain('&gt;');
+    expect(result).not.toContain('<script>');
+  });
+
+  test('escapes &', () => {
+    expect(escapeHtml('a & b')).toBe('a &amp; b');
+  });
+
+  test('escapes double quotes', () => {
+    expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+  });
+
+  test('handles an empty string', () => {
+    expect(escapeHtml('')).toBe('');
+  });
+
+  test('escapes a complex HTML string', () => {
+    const result = escapeHtml('<div class="test">Hello & World</div>');
+    expect(result).not.toContain('<div');
+    expect(result).toContain('&lt;');
+    expect(result).toContain('&gt;');
+    expect(result).toContain('&amp;');
+    expect(result).toContain('&quot;');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderJsonTree
+// ---------------------------------------------------------------------------
+describe('renderJsonTree', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  test('renders null as a json-null span', () => {
+    renderJsonTree(container, null);
+    const span = container.querySelector('.json-null');
+    expect(span).not.toBeNull();
+    expect(span.textContent).toBe('null');
+  });
+
+  test('renders undefined as a json-null span', () => {
+    renderJsonTree(container, undefined);
+    expect(container.querySelector('.json-null')).not.toBeNull();
+  });
+
+  test('renders a string with surrounding quotes', () => {
+    renderJsonTree(container, 'hello');
+    const span = container.querySelector('.json-string');
+    expect(span).not.toBeNull();
+    expect(span.textContent).toBe('"hello"');
+  });
+
+  test('renders a number', () => {
+    renderJsonTree(container, 42);
+    const span = container.querySelector('.json-number');
+    expect(span).not.toBeNull();
+    expect(span.textContent).toBe('42');
+  });
+
+  test('renders a boolean true', () => {
+    renderJsonTree(container, true);
+    const span = container.querySelector('.json-boolean');
+    expect(span).not.toBeNull();
+    expect(span.textContent).toBe('true');
+  });
+
+  test('renders a boolean false', () => {
+    renderJsonTree(container, false);
+    expect(container.querySelector('.json-boolean').textContent).toBe('false');
+  });
+
+  test('renders an empty object as {}', () => {
+    renderJsonTree(container, {});
+    expect(container.textContent).toBe('{}');
+  });
+
+  test('renders an empty array as []', () => {
+    renderJsonTree(container, []);
+    expect(container.textContent).toBe('[]');
+  });
+
+  test('renders object keys with quoted notation', () => {
+    renderJsonTree(container, { name: 'Alice', age: 30 });
+    const keys = Array.from(container.querySelectorAll('.json-key')).map(
+      (k) => k.textContent
+    );
+    expect(keys).toContain('"name"');
+    expect(keys).toContain('"age"');
+  });
+
+  test('renders array indices with bracket notation', () => {
+    renderJsonTree(container, ['a', 'b']);
+    const keys = container.querySelectorAll('.json-key');
+    expect(keys[0].textContent).toBe('[0]');
+    expect(keys[1].textContent).toBe('[1]');
+  });
+
+  test('renders nested objects recursively', () => {
+    renderJsonTree(container, { outer: { inner: 'value' } });
+    const strings = container.querySelectorAll('.json-string');
+    expect(strings.length).toBe(1);
+    expect(strings[0].textContent).toBe('"value"');
+  });
+
+  test('renders mixed-type object', () => {
+    renderJsonTree(container, { str: 'hi', num: 1, flag: true, nothing: null });
+    expect(container.querySelector('.json-string')).not.toBeNull();
+    expect(container.querySelector('.json-number')).not.toBeNull();
+    expect(container.querySelector('.json-boolean')).not.toBeNull();
+    expect(container.querySelector('.json-null')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCaseCard
+// ---------------------------------------------------------------------------
+describe('createCaseCard', () => {
+  function makeSuccess(overrides = {}) {
+    return {
+      receiptNumber: 'IOE1234567890',
+      error: false,
+      status: 200,
+      data: { caseStatus: 'Case Was Approved' },
+      ...overrides,
+    };
+  }
+
+  function makeError(overrides = {}) {
+    return {
+      receiptNumber: 'IOE1234567890',
+      error: true,
+      status: 404,
+      statusText: 'Not Found',
+      data: null,
+      ...overrides,
+    };
+  }
+
+  test('displays the receipt number', () => {
+    const card = createCaseCard(makeSuccess());
+    expect(card.querySelector('.receipt-number').textContent).toBe('IOE1234567890');
+  });
+
+  test('adds "success" class for non-error results', () => {
+    const card = createCaseCard(makeSuccess());
+    expect(card.classList.contains('success')).toBe(true);
+    expect(card.classList.contains('error')).toBe(false);
+  });
+
+  test('adds "error" class for error results', () => {
+    const card = createCaseCard(makeError());
+    expect(card.classList.contains('error')).toBe(true);
+    expect(card.classList.contains('success')).toBe(false);
+  });
+
+  test('badge shows case status for successful results', () => {
+    const card = createCaseCard(makeSuccess({ data: { caseStatus: 'Approved' } }));
+    expect(card.querySelector('.case-status-badge').textContent).toContain('Approved');
+  });
+
+  test('badge shows error code for error results', () => {
+    const card = createCaseCard(makeError({ status: 503 }));
+    expect(card.querySelector('.case-status-badge').textContent).toContain('503');
+  });
+
+  test('error message shows statusText', () => {
+    const card = createCaseCard(
+      makeError({ statusText: 'Internal Server Error', status: 500 })
+    );
+    const msg = card.querySelector('.error-message');
+    expect(msg).not.toBeNull();
+    expect(msg.textContent).toContain('Internal Server Error');
+  });
+
+  test('shows "Unknown error" when statusText is absent', () => {
+    const card = createCaseCard(makeError({ statusText: undefined }));
+    const msg = card.querySelector('.error-message');
+    expect(msg.textContent).toContain('Unknown error');
+  });
+
+  test('body starts in collapsed state', () => {
+    const card = createCaseCard(makeSuccess());
+    expect(card.querySelector('.case-body').classList.contains('collapsed')).toBe(true);
+  });
+
+  test('clicking the header toggles the collapsed state', () => {
+    const card = createCaseCard(makeSuccess());
+    const header = card.querySelector('.case-header');
+    const body = card.querySelector('.case-body');
+
+    expect(body.classList.contains('collapsed')).toBe(true);
+    header.click();
+    expect(body.classList.contains('collapsed')).toBe(false);
+    header.click();
+    expect(body.classList.contains('collapsed')).toBe(true);
+  });
+
+  test('success card contains a json-tree element', () => {
+    const card = createCaseCard(makeSuccess());
+    expect(card.querySelector('.json-tree')).not.toBeNull();
+  });
+
+  test('success card contains "Show Raw JSON" and "Copy JSON" buttons', () => {
+    const card = createCaseCard(makeSuccess());
+    const buttons = card.querySelectorAll('.btn-small');
+    const labels = Array.from(buttons).map((b) => b.textContent);
+    expect(labels).toContain('Show Raw JSON');
+    expect(labels).toContain('Copy JSON');
+  });
+
+  test('raw JSON is hidden by default', () => {
+    const card = createCaseCard(makeSuccess());
+    const rawEl = card.querySelector('.raw-json');
+    expect(rawEl).not.toBeNull();
+    expect(rawEl.classList.contains('hidden')).toBe(true);
+  });
+
+  test('clicking "Show Raw JSON" toggles visibility and button label', () => {
+    const card = createCaseCard(makeSuccess());
+    document.body.appendChild(card); // needs to be in DOM for click propagation
+
+    const rawToggle = Array.from(card.querySelectorAll('.btn-small')).find(
+      (b) => b.textContent === 'Show Raw JSON'
+    );
+    const rawEl = card.querySelector('.raw-json');
+
+    rawToggle.click();
+    expect(rawEl.classList.contains('hidden')).toBe(false);
+    expect(rawToggle.textContent).toBe('Hide Raw JSON');
+
+    rawToggle.click();
+    expect(rawEl.classList.contains('hidden')).toBe(true);
+    expect(rawToggle.textContent).toBe('Show Raw JSON');
+
+    document.body.removeChild(card);
+  });
+
+  test('raw JSON pre element contains serialised JSON', () => {
+    const data = { caseStatus: 'Approved', id: 42 };
+    const card = createCaseCard(makeSuccess({ data }));
+    const rawEl = card.querySelector('.raw-json');
+    expect(rawEl.textContent).toBe(JSON.stringify(data, null, 2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderCases
+// ---------------------------------------------------------------------------
+describe('renderCases', () => {
+  beforeEach(setupPopupDom);
+
+  test('renders one card per case result', () => {
+    const cases = [
+      { receiptNumber: 'IOE1111111111', error: false, status: 200, data: {} },
+      { receiptNumber: 'EAC2222222222', error: false, status: 200, data: {} },
+    ];
+    renderCases(cases);
+    const container = document.getElementById('cases-container');
+    expect(container.querySelectorAll('.case-card')).toHaveLength(2);
+  });
+
+  test('clears previous cards before rendering', () => {
+    const singleCase = [
+      { receiptNumber: 'IOE1111111111', error: false, status: 200, data: {} },
+    ];
+    renderCases(singleCase);
+    renderCases(singleCase);
+    expect(
+      document.getElementById('cases-container').querySelectorAll('.case-card')
+    ).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toggleAll
+// ---------------------------------------------------------------------------
+describe('toggleAll', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="case-body collapsed"></div>
+      <div class="case-body collapsed"></div>
+      <button class="toggle-btn">&#x25B6;</button>
+      <button class="toggle-btn">&#x25B6;</button>
+    `;
+  });
+
+  test('expand=true removes collapsed class from all bodies', () => {
+    toggleAll(true);
+    document.querySelectorAll('.case-body').forEach((body) => {
+      expect(body.classList.contains('collapsed')).toBe(false);
+    });
+  });
+
+  test('expand=false adds collapsed class to all bodies', () => {
+    toggleAll(true);   // first expand
+    toggleAll(false);  // then collapse
+    document.querySelectorAll('.case-body').forEach((body) => {
+      expect(body.classList.contains('collapsed')).toBe(true);
+    });
+  });
+
+  test('expand=true sets toggle button to down arrow', () => {
+    toggleAll(true);
+    document.querySelectorAll('.toggle-btn').forEach((btn) => {
+      expect(btn.innerHTML).toBe('&#x25BC;');
+    });
+  });
+
+  test('expand=false sets toggle button to right arrow', () => {
+    toggleAll(true);
+    toggleAll(false);
+    document.querySelectorAll('.toggle-btn').forEach((btn) => {
+      expect(btn.innerHTML).toBe('&#x25B6;');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateTimestamp
+// ---------------------------------------------------------------------------
+describe('updateTimestamp', () => {
+  beforeEach(setupPopupDom);
+
+  test('does nothing when timestamp is falsy', () => {
+    updateTimestamp(null);
+    expect(document.getElementById('last-updated').textContent).toBe('');
+  });
+
+  test('sets last-updated text for a valid timestamp', () => {
+    const ts = new Date('2024-01-15T10:30:00').getTime();
+    updateTimestamp(ts);
+    const text = document.getElementById('last-updated').textContent;
+    expect(text).toContain('Last updated:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// showEmptyState
+// ---------------------------------------------------------------------------
+describe('showEmptyState', () => {
+  beforeEach(setupPopupDom);
+
+  test('hides the cases container', () => {
+    document.getElementById('cases-container').classList.remove('hidden');
+    showEmptyState();
+    expect(
+      document.getElementById('cases-container').classList.contains('hidden')
+    ).toBe(true);
+  });
+
+  test('shows the empty-state element', () => {
+    showEmptyState();
+    expect(
+      document.getElementById('empty-state').classList.contains('hidden')
+    ).toBe(false);
+  });
+
+  test('sets the status text to "No cases loaded"', () => {
+    showEmptyState();
+    expect(document.getElementById('status').textContent).toBe('No cases loaded');
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,45 @@
+// Global mocks for Chrome Extension APIs
+global.chrome = {
+  runtime: {
+    onMessage: {
+      addListener: jest.fn(),
+    },
+    sendMessage: jest.fn(),
+    lastError: null,
+  },
+  storage: {
+    local: {
+      get: jest.fn(),
+      set: jest.fn(),
+    },
+  },
+  action: {
+    setBadgeText: jest.fn(),
+    setBadgeBackgroundColor: jest.fn(),
+  },
+  tabs: {
+    query: jest.fn(),
+    sendMessage: jest.fn(),
+  },
+};
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+// Mock MutationObserver to prevent DOM mutation side effects during tests
+global.MutationObserver = class {
+  constructor(callback) {
+    this.callback = callback;
+  }
+  observe() {}
+  disconnect() {}
+};
+
+// Mock navigator.clipboard
+Object.defineProperty(global.navigator, 'clipboard', {
+  value: {
+    writeText: jest.fn().mockResolvedValue(undefined),
+  },
+  writable: true,
+  configurable: true,
+});


### PR DESCRIPTION
Adds Jest 29 + jsdom test suite covering all three extension source files.

Closes #6

Generated with [Claude Code](https://claude.ai/code)