### PR TITLE
fix: resolve all 26 failing tests

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 const RECEIPT_REGEX = /\b(IOE|EAC|WAC|LIN|SRC|NBC|MSC|YSC|MCT)\d{10}\b/g;
 
 function extractReceiptNumbers() {
-  const bodyText = document.body.innerText;
+  const bodyText = document.body.textContent;
   const matches = bodyText.match(RECEIPT_REGEX);
   if (!matches) return [];
   return [...new Set(matches)].sort();
@@ -53,7 +53,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Observe DOM mutations for SPA content loading
 const observer = new MutationObserver(() => {
-  if (document.body.innerText.match(RECEIPT_REGEX)) {
+  if (document.body.textContent.match(RECEIPT_REGEX)) {
     main();
     observer.disconnect();
   }

--- a/popup.js
+++ b/popup.js
@@ -183,7 +183,7 @@ function renderJsonTree(container, obj, depth) {
 function escapeHtml(str) {
   const div = document.createElement('div');
   div.textContent = str;
-  return div.innerHTML;
+  return div.innerHTML.replace(/"/g, '&quot;');
 }
 
 function toggleAll(expand) {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -391,7 +391,7 @@ describe('toggleAll', () => {
   test('expand=true sets toggle button to down arrow', () => {
     toggleAll(true);
     document.querySelectorAll('.toggle-btn').forEach((btn) => {
-      expect(btn.innerHTML).toBe('&#x25BC;');
+      expect(btn.innerHTML).toBe('▼');
     });
   });
 
@@ -399,7 +399,7 @@ describe('toggleAll', () => {
     toggleAll(true);
     toggleAll(false);
     document.querySelectorAll('.toggle-btn').forEach((btn) => {
-      expect(btn.innerHTML).toBe('&#x25B6;');
+      expect(btn.innerHTML).toBe('▶');
     });
   });
 });


### PR DESCRIPTION
Fixes #9

- Replace `innerText` with `textContent` in `content.js` (JSDOM does not support `innerText`)
- Add double-quote escaping to `escapeHtml` in `popup.js`
- Correct `toggleAll` test assertions to use actual Unicode chars instead of HTML entity strings

Generated with [Claude Code](https://claude.ai/code)